### PR TITLE
Add Star History chart and tidy Acknowledgments logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,23 +271,22 @@ This research was also supported by The '_Israeli Smart Transportation Research 
 
 <p align="center">
 <a href="https://istrc.net.technion.ac.il/">
-<img src="https://github.com/krichelj/PyDiffGame/blob/master/images/Logo_ISTRC_Green_English.png?raw=true" width="233"  alt=""/>
+<img src="https://github.com/krichelj/PyDiffGame/blob/master/images/Logo_ISTRC_Green_English.png?raw=true" height="80" alt="ISTRC"/>
 </a>
 &emsp;
 <a href="https://in.bgu.ac.il/en/Pages/default.aspx">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTZ8GbtJiX8lNUygX7-inRBuWESK438jWbRjQ&s">
   <source media="(prefers-color-scheme: light)" srcset="https://tamrur.bgu.ac.il/restore/BGU.sig.png">
-  <img alt="BGU Logo" src="https://tamrur.bgu.ac.il/restore/BGU.sig.png" width="233" class="bgu-logo-dark">
+  <img alt="Ben-Gurion University of the Negev" src="https://tamrur.bgu.ac.il/restore/BGU.sig.png" height="80">
 </picture>
 </a>
-&emsp;
 &emsp;
 <a href="https://helmsleytrust.org/">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://helmsleytrust.org/wp-content/themes/helmsley/assets/img/helmsley-charitable-trust-logo-white.png">
   <source media="(prefers-color-scheme: light)" srcset="https://helmsleytrust.org/wp-content/themes/helmsley/assets/img/helmsley-charitable-trust-logo-blue.png">
-  <img alt="Helmsley Charitable Trust" src="https://helmsleytrust.org/wp-content/themes/helmsley/assets/img/helmsley-charitable-trust-logo-blue.png" width="233">
+  <img alt="Helmsley Charitable Trust" src="https://helmsleytrust.org/wp-content/themes/helmsley/assets/img/helmsley-charitable-trust-logo-blue.png" height="80">
 </picture>
 </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ This research was also supported by The '_Israeli Smart Transportation Research 
 <p align="center">
 <a href="https://star-history.com/#krichelj/PyDiffGame&Date">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date&theme=dark"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date&theme=dark"/>
   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date" width="600"/>
 </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ This research was also supported by The '_Israeli Smart Transportation Research 
 <p align="center">
 <a href="https://star-history.com/#krichelj/PyDiffGame&Date">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date&theme=dark"/>
+  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date"/>
   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=krichelj/PyDiffGame&type=Date" width="600"/>
 </picture>
 </a>


### PR DESCRIPTION
## Summary

- Add a **Star History** section to the README, embedding a live [star-history.com](https://star-history.com) chart that auto-updates and adapts to the GitHub theme (dark chart in dark mode, light chart in light mode), with a static fallback for renderers that don't support `<picture>`.
- Add the section to the table of contents.
- Tidy the **Acknowledgments** sponsor logos: size them by a uniform height instead of a fixed width and normalize the spacing, so they form a clean even row on desktop and an organized uniform stack when they wrap on mobile.

## Notes

- The Ben-Gurion University logo still uses a black-background thumbnail in dark mode. Fully fixing it needs a transparent white BGU logo vendored into `images/`, which couldn't be fetched in this environment due to the network egress allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_