### PR TITLE
Enable manual publish trigger + PyPI token auth

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -64,3 +65,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          # Authenticate with a PyPI API token stored as the repository secret
+          # PYPI_API_TOKEN. (Leave this secret unset to fall back to OIDC
+          # Trusted Publishing instead.)
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Adds `workflow_dispatch` to the publish workflow so it can be run on demand, and configures token authentication via the `PYPI_API_TOKEN` repository secret (falls back to Trusted Publishing if the secret is unset). Prepares the v2.0.0 PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_