### PR TITLE
Use PyPI Trusted Publishing (OIDC) for publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,11 +61,11 @@ jobs:
           name: release-dists
           path: dist/
 
+      # Authentication is via PyPI Trusted Publishing (OIDC) — no token needed.
+      # Configure the trusted publisher once on PyPI (see below) with:
+      #   owner: krichelj  repo: PyDiffGame
+      #   workflow: python-publish.yml  environment: pypi
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          # Authenticate with a PyPI API token stored as the repository secret
-          # PYPI_API_TOKEN. (Leave this secret unset to fall back to OIDC
-          # Trusted Publishing instead.)
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Switches the publish workflow to authenticate via PyPI Trusted Publishing (OIDC) — removes the token `password` input (an unset token secret would break OIDC), keeps `workflow_dispatch` for on-demand runs and the `pypi` environment + `id-token: write`.

Requires a one-time trusted-publisher registration on PyPI: owner `krichelj`, repo `PyDiffGame`, workflow `python-publish.yml`, environment `pypi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_