### PR TITLE
Create a matching GitHub Release on every publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,16 +1,17 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# Publishes the package to PyPI and creates the matching GitHub Release.
+#
+# Flow: bump `version` in pyproject.toml, then run this workflow
+# (Actions -> Upload Python Package -> Run workflow). It builds the dists,
+# uploads them to PyPI via Trusted Publishing, and creates a GitHub Release
+# tagged v<version> with auto-generated notes and the dists attached.
+#
+# It is idempotent: re-running for an already-published version skips the PyPI
+# upload (skip-existing) and updates the existing release's assets, so it is
+# safe to run against the current version to backfill a release.
 
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -43,16 +44,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
       url: https://pypi.org/project/PyDiffGame/
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
 
     steps:
       - name: Retrieve release distributions
@@ -62,10 +56,45 @@ jobs:
           path: dist/
 
       # Authentication is via PyPI Trusted Publishing (OIDC) — no token needed.
-      # Configure the trusted publisher once on PyPI (see below) with:
-      #   owner: krichelj  repo: PyDiffGame
-      #   workflow: python-publish.yml  environment: pypi
+      # Trusted publisher on PyPI: owner krichelj, repo PyDiffGame,
+      # workflow python-publish.yml, environment pypi.
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          # Don't fail if this version is already on PyPI (idempotent re-runs).
+          skip-existing: true
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-publish
+    permissions:
+      # Needed to create the release and its tag.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v5
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Create or update the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(grep -m1 '^version' pyproject.toml | sed -E 's/version *= *"([^"]+)".*/\1/')"
+          tag="v${version}"
+          echo "Releasing ${tag}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release ${tag} already exists - refreshing its assets."
+            gh release upload "$tag" dist/* --clobber
+          else
+            gh release create "$tag" dist/* \
+              --title "$tag" \
+              --generate-notes \
+              --target "$GITHUB_SHA"
+          fi

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
 
       - name: Build release distributions
         run: uv build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-dists
           path: dist/
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 


### PR DESCRIPTION
Makes a GitHub Release an automatic output of publishing.

- Trigger is now `workflow_dispatch` only (removing `release: published` avoids a trigger loop now that the workflow *creates* releases).
- PyPI upload uses `skip-existing: true`, so re-running for an already-published version is safe (idempotent).
- New `github-release` job creates/updates the `v<version>` release (version read from `pyproject.toml`) with auto-generated notes and the built dists attached, using the runner's built-in `gh` CLI (first-party, no extra Node action).

**New release flow:** bump `version` in `pyproject.toml` → Actions → *Upload Python Package* → *Run workflow*. It publishes to PyPI and creates the matching GitHub Release.

Running it once now against the current version (`2.0.0`) backfills the `v2.0.0` release without re-uploading to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_