### PR TITLE
docs: document the release flow in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,25 @@ Continuous integration runs the formatter check, the linter, the type checker
 and the full suite (all via uv) across Python 3.11–3.14, so please make sure
 they pass locally.
 
+## Releasing
+
+Publishing a new version to PyPI and creating the matching GitHub Release is a
+single automated step:
+
+1. Bump `version` in `pyproject.toml` (e.g. `2.0.0` -> `2.1.0`) and merge it to
+   `master`.
+2. Run the publish workflow: **Actions -> Upload Python Package -> Run workflow**
+   (on `master`).
+
+That run builds the distributions with `uv build`, uploads them to PyPI via
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no
+tokens or secrets), and then creates a `v<version>` GitHub Release with
+auto-generated notes and the built wheels/sdist attached.
+
+The workflow is idempotent: re-running it for a version already on PyPI skips
+the upload (`skip-existing`) and just refreshes the release assets, so it is
+safe to re-run.
+
 Thank you for your contribution!
 
 Joshua Shay Kricheli


### PR DESCRIPTION
Documents the release process in CONTRIBUTING: bump `version`, run the *Upload Python Package* workflow, which publishes to PyPI via Trusted Publishing and creates the matching `v<version>` GitHub Release (notes + built artifacts). Notes that the workflow is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_