### PR TITLE
uv-first docs, PyPI/GitHub README parity, and automatic carry-at-9 versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,13 +1,14 @@
-# Publishes the package to PyPI and creates the matching GitHub Release.
+# Publishes the package to PyPI and creates the matching GitHub Release,
+# auto-incrementing the version each run.
 #
-# Flow: bump `version` in pyproject.toml, then run this workflow
-# (Actions -> Upload Python Package -> Run workflow). It builds the dists,
-# uploads them to PyPI via Trusted Publishing, and creates a GitHub Release
-# tagged v<version> with auto-generated notes and the dists attached.
+# Flow (just run it — Actions -> Upload Python Package -> Run workflow):
+#   1. bump-version  : increment the version (carry-at-9 via tools/bump_version.py),
+#                      commit it back to master.
+#   2. release-build : build the dists from the bumped master.
+#   3. pypi-publish  : upload to PyPI via Trusted Publishing (OIDC, no tokens).
+#   4. github-release: create the v<version> GitHub Release with notes + dists.
 #
-# It is idempotent: re-running for an already-published version skips the PyPI
-# upload (skip-existing) and updates the existing release's assets, so it is
-# safe to run against the current version to backfill a release.
+# Versions roll over at 9: 2.0.9 -> 2.1.0, 2.9.9 -> 3.0.0.
 
 name: Upload Python Package
 
@@ -18,11 +19,39 @@ permissions:
   contents: read
 
 jobs:
-  release-build:
+  bump-version:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Increment the version (carry-at-9)
+        id: bump
+        run: |
+          new="$(python3 tools/bump_version.py)"
+          echo "version=$new" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $new"
+
+      - name: Commit and push the bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml src/PyDiffGame/__init__.py
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
+          git push origin HEAD:master
+
+  release-build:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: master  # the bumped commit
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -37,9 +66,9 @@ jobs:
           path: dist/
 
   pypi-publish:
-    runs-on: ubuntu-latest
     needs:
       - release-build
+    runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
@@ -66,15 +95,18 @@ jobs:
           skip-existing: true
 
   github-release:
-    runs-on: ubuntu-latest
     needs:
+      - bump-version
       - pypi-publish
+    runs-on: ubuntu-latest
     permissions:
       # Needed to create the release and its tag.
       contents: write
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: master
 
       - name: Retrieve release distributions
         uses: actions/download-artifact@v5
@@ -85,9 +117,9 @@ jobs:
       - name: Create or update the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.bump-version.outputs.version }}
         run: |
-          version="$(grep -m1 '^version' pyproject.toml | sed -E 's/version *= *"([^"]+)".*/\1/')"
-          tag="v${version}"
+          tag="v${VERSION}"
           echo "Releasing ${tag}"
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "Release ${tag} already exists - refreshing its assets."
@@ -96,5 +128,5 @@ jobs:
             gh release create "$tag" dist/* \
               --title "$tag" \
               --generate-notes \
-              --target "$GITHUB_SHA"
+              --target master
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# PyDiffGame — repository guide for Claude
+
+## Python tooling (uv-first)
+- Use **uv** for everything; pip is only a documented fallback.
+  - `uv sync --extra dev`, `uv run pytest`, `uv run ruff check`, `uv run ruff format`,
+    `uv run mypy src/PyDiffGame`, `uv build`.
+- Keep the quality gates green before committing: ruff format, ruff check, mypy on
+  `src/PyDiffGame`, and the pytest suite — all via `uv run`.
+
+## Versioning (carry-at-9)
+- The version is `X.Y.Z` with single-digit components that roll over at 9:
+  `2.0.9 -> 2.1.0`, `2.9.9 -> 3.0.0` (the major keeps growing).
+- Increment **only** via `tools/bump_version.py`, which updates the version in both
+  `pyproject.toml` and `src/PyDiffGame/__init__.py`. Never hand-edit version strings.
+- The version is bumped **automatically** by the publish workflow on each release, so
+  do not bump it in ordinary PRs — the release run does it.
+
+## Releasing
+- `Actions -> Upload Python Package -> Run workflow` (on `master`). The workflow
+  auto-increments the version, commits it to `master`, builds with `uv build`,
+  publishes to PyPI via Trusted Publishing (OIDC, no tokens), and creates the matching
+  `v<version>` GitHub Release with notes and the built dists attached. It is idempotent
+  (`skip-existing`).
+
+## Docs
+- `README.md` is the single canonical readme and is also the PyPI long-description
+  (`pyproject.toml: readme = "README.md"`), so its image/file links must be **absolute**
+  (`raw.githubusercontent.com/.../master/...` for images, `github.com/.../blob/master/...`
+  for files) so they render on PyPI.
+- Keep `docs/README.md` identical to `README.md`.
+- README figures are generated from the live solver:
+  `uv run python tools/generate_readme_figures.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,22 +41,26 @@ they pass locally.
 
 ## Releasing
 
-Publishing a new version to PyPI and creating the matching GitHub Release is a
-single automated step:
+Publishing a new version is a single automated step — just run the publish
+workflow: **Actions -> Upload Python Package -> Run workflow** (on `master`).
 
-1. Bump `version` in `pyproject.toml` (e.g. `2.0.0` -> `2.1.0`) and merge it to
+The run automatically:
+
+1. **Increments the version** with `tools/bump_version.py`, which rolls each
+   component over at 9 (`2.0.9 -> 2.1.0`, `2.9.9 -> 3.0.0`), updating both
+   `pyproject.toml` and `src/PyDiffGame/__init__.py`, and commits the bump to
    `master`.
-2. Run the publish workflow: **Actions -> Upload Python Package -> Run workflow**
-   (on `master`).
+2. Builds the distributions with `uv build`.
+3. Uploads them to PyPI via
+   [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no
+   tokens or secrets).
+4. Creates a `v<version>` GitHub Release with auto-generated notes and the built
+   wheels/sdist attached.
 
-That run builds the distributions with `uv build`, uploads them to PyPI via
-[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no
-tokens or secrets), and then creates a `v<version>` GitHub Release with
-auto-generated notes and the built wheels/sdist attached.
-
-The workflow is idempotent: re-running it for a version already on PyPI skips
-the upload (`skip-existing`) and just refreshes the release assets, so it is
-safe to re-run.
+You normally never edit the version by hand. To bump it locally (e.g. to test),
+run `uv run python tools/bump_version.py` (`--dry-run` to preview, `--current`
+to print the current version). The PyPI upload is idempotent (`skip-existing`),
+so re-running the workflow is safe.
 
 Thank you for your contribution!
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img alt="PyDiffGame logo" src="images/logo.png" width="420"/>
+    <img alt="PyDiffGame logo" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/logo.png" width="420"/>
 </p>
 
 <p align="center">
@@ -68,22 +68,32 @@ accounting on a common yardstick, and ready-made plotting.
 
 # Installation
 
-Install the latest release from PyPI:
+PyDiffGame is published on [PyPI](https://pypi.org/project/PyDiffGame/) and is
+managed with [**uv**](https://docs.astral.sh/uv/). Add it to your project:
 
 ```bash
-pip install PyDiffGame
+uv add PyDiffGame
 ```
 
 To run the bundled examples (which additionally need
 [`python-control`](https://python-control.readthedocs.io/)):
 
 ```bash
-pip install "PyDiffGame[examples]"
+uv add "PyDiffGame[examples]"
 ```
 
-To work on the package itself, this project is managed with
-[**uv**](https://docs.astral.sh/uv/). Clone it and sync the locked development
-environment:
+<details>
+<summary><b>Prefer pip?</b> It works as a fallback.</summary>
+
+```bash
+pip install PyDiffGame
+pip install "PyDiffGame[examples]"   # with the examples extra
+```
+
+</details>
+
+To work on the package itself, clone it and sync the locked development
+environment with uv:
 
 ```bash
 git clone https://github.com/krichelj/PyDiffGame.git
@@ -92,7 +102,10 @@ uv sync --extra dev          # creates .venv with the exact locked dependencies
 uv run pre-commit install    # enable the formatting / lint / type-check hooks
 ```
 
-Then run anything through `uv run` (`uv run pytest`, `uv run python -m PyDiffGame.examples.MassesWithSpringsComparison`, …).
+Then run anything through `uv run` (`uv run pytest`,
+`uv run python -m PyDiffGame.examples.MassesWithSpringsComparison`, …). Pip users
+can instead `pip install -e ".[dev]"`, though uv is recommended for the exact
+locked environment.
 
 # Quick start
 
@@ -183,7 +196,7 @@ To show the package in action we compare a differential game against an LQR on a
 masses connected by springs — a textbook coupled, oscillatory system:
 
 <p align="center">
-    <img alt="Two masses connected by springs between two walls" src="images/readme/masses_schematic.png" width="760"/>
+    <img alt="Two masses connected by springs between two walls" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_schematic.png" width="760"/>
 </p>
 
 The physical input space is decomposed along the **modal** directions of $M^{-1}K$, so each
@@ -245,11 +258,11 @@ monolithic optimum **to numerical precision**: the two state trajectories coinci
 (they differ by ~10⁻⁷) and the costs are equal:
 
 <p align="center">
-    <img alt="State trajectories: the decomposed game reproduces the monolithic LQR" src="images/readme/masses_game_vs_lqr.png" width="860"/>
+    <img alt="State trajectories: the decomposed game reproduces the monolithic LQR" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_game_vs_lqr.png" width="860"/>
 </p>
 
 <p align="center">
-    <img alt="Cost comparison: the modal game recovers the LQR optimum" src="images/readme/masses_cost.png" width="440"/>
+    <img alt="Cost comparison: the modal game recovers the LQR optimum" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_cost.png" width="440"/>
 </p>
 
 For this modally-decoupled system the decomposition is **lossless** — and it buys
@@ -257,7 +270,7 @@ For this modally-decoupled system the decomposition is **lossless** — and it b
 player, without re-tuning one monolithic cost matrix.
 
 > The figures above are regenerated from the live solver by
-> [`tools/generate_readme_figures.py`](tools/generate_readme_figures.py)
+> [`tools/generate_readme_figures.py`](https://github.com/krichelj/PyDiffGame/blob/master/tools/generate_readme_figures.py)
 > (`uv run python tools/generate_readme_figures.py`), so they always match the current code.
 
 # More examples
@@ -288,7 +301,7 @@ uv run mypy        src/PyDiffGame            # type-check
 ```
 
 Continuous integration runs the formatter check, linter, type checker and full suite on
-Python 3.11–3.14. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Python 3.11–3.14. See [CONTRIBUTING.md](https://github.com/krichelj/PyDiffGame/blob/master/CONTRIBUTING.md) for details.
 
 # Citing
 
@@ -304,7 +317,7 @@ If you use this work, please cite our paper:
     doi={10.1109/MED51440.2021.9480269}}
 ```
 
-Further details can be found in the [citation document](CITATIONS.bib).
+Further details can be found in the [citation document](https://github.com/krichelj/PyDiffGame/blob/master/CITATIONS.bib).
 
 # Acknowledgments
 
@@ -316,7 +329,7 @@ and Bar-Ilan Universities, Israel.
 
 <p align="center">
 <a href="https://istrc.net.technion.ac.il/">
-<img src="images/Logo_ISTRC_Green_English.png" height="80" alt="ISTRC"/>
+<img src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/Logo_ISTRC_Green_English.png" height="80" alt="ISTRC"/>
 </a>
 &emsp;
 <a href="https://in.bgu.ac.il/en/Pages/default.aspx">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,59 +1,116 @@
 <p align="center">
-    <img alt="Logo" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/logo.png"/>
+    <img alt="PyDiffGame logo" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/logo.png" width="420"/>
 </p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Tests](https://github.com/krichelj/PyDiffGame/actions/workflows/tests.yml/badge.svg)](https://github.com/krichelj/PyDiffGame/actions/workflows/tests.yml) [![Upload Python Package](https://github.com/krichelj/PyDiffGame/actions/workflows/python-publish.yml/badge.svg)](https://github.com/krichelj/PyDiffGame/actions/workflows/python-publish.yml) [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://www.python.org/)
+<p align="center">
+    <i>Nash-equilibrium control for multi-objective dynamical systems, built on coupled Riccati equations.</i>
+</p>
 
+<p align="center">
+<a href="https://github.com/krichelj/PyDiffGame/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/krichelj/PyDiffGame/actions/workflows/tests.yml/badge.svg?branch=master"></a>
+<a href="https://pypi.org/project/PyDiffGame/"><img alt="PyPI" src="https://img.shields.io/pypi/v/PyDiffGame.svg"></a>
+<a href="https://www.python.org/"><img alt="Python" src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg"></a>
+<a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
+<a href="https://github.com/astral-sh/ruff"><img alt="Ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
+<a href="https://mypy-lang.org/"><img alt="Checked with mypy" src="https://img.shields.io/badge/mypy-checked-2a6db2.svg"></a>
+<a href="https://docs.astral.sh/uv/"><img alt="uv" src="https://img.shields.io/badge/managed%20with-uv-261230.svg"></a>
+</p>
 
-  * [What is this?](#what-is-this)
-  * [Installation](#installation)
-  * [Quick start](#quick-start)
-  * [Input parameters](#input-parameters)
-  * [Tutorial](#tutorial)
-  * [Testing and development](#testing-and-development)
-  * [Authors](#authors)
-  * [Acknowledgments](#acknowledgments)
-  * [Star History](#star-history)
+---
+
+* [What is this?](#what-is-this)
+* [Why differential games?](#why-differential-games)
+* [Installation](#installation)
+* [Quick start](#quick-start)
+* [Input parameters](#input-parameters)
+* [Tutorial: masses on springs](#tutorial-masses-on-springs)
+* [More examples](#more-examples)
+* [Testing and development](#testing-and-development)
+* [Citing](#citing)
+* [Acknowledgments](#acknowledgments)
+* [Star history](#star-history)
 
 # What is this?
 
-[`PyDiffGame`](https://github.com/krichelj/PyDiffGame) is a Python implementation of a Nash Equilibrium solution to differential games, based on a reduction of Game Hamilton-Jacobi-Bellman (GHJB) equations to coupled Game Algebraic and Differential Riccati equations, associated with multi-objective dynamical control systems.
-The method relies on the formulation given in:
+[`PyDiffGame`](https://github.com/krichelj/PyDiffGame) is a Python implementation of a
+**Nash-equilibrium solution to differential games**. It reduces the Game
+Hamilton–Jacobi–Bellman (GHJB) equations to a set of *coupled* Game Algebraic and
+Differential Riccati equations, and solves them to synthesize feedback controllers for
+multi-objective dynamical control systems.
 
- - The thesis work "_Differential Games for Compositional Handling of Competing Control Tasks_"
-   ([Research Gate](https://www.researchgate.net/publication/359819808_Differential_Games_for_Compositional_Handling_of_Competing_Control_Tasks))
+In one sentence: where a classical Linear-Quadratic Regulator (LQR) folds every control
+task into **one** quadratic cost and solves **one** Riccati equation, `PyDiffGame` keeps
+each task as a separate *player*, and solves the coupled Riccati system whose fixed point
+is their Nash equilibrium. A plain LQR is simply the one-player special case.
 
- - The conference article "_Composition of Dynamic Control Objectives Based on Differential Games_"
-([IEEE](https://ieeexplore.ieee.org/document/9480269) |
-[Research Gate](https://www.researchgate.net/publication/353452024_Composition_of_Dynamic_Control_Objectives_Based_on_Differential_Games))
+The method follows the formulation in:
 
-The package requires **Python >= 3.11** and is tested on CPython 3.11, 3.12, 3.13 and 3.14.
+- The thesis _“Differential Games for Compositional Handling of Competing Control Tasks”_
+  ([ResearchGate](https://www.researchgate.net/publication/359819808_Differential_Games_for_Compositional_Handling_of_Competing_Control_Tasks))
+- The conference paper _“Composition of Dynamic Control Objectives Based on Differential Games”_
+  ([IEEE](https://ieeexplore.ieee.org/document/9480269) ·
+  [ResearchGate](https://www.researchgate.net/publication/353452024_Composition_of_Dynamic_Control_Objectives_Based_on_Differential_Games))
+
+The package requires **Python ≥ 3.11** and is tested on CPython 3.11, 3.12, 3.13 and 3.14.
+
+# Why differential games?
+
+| Classical LQR | `PyDiffGame` |
+| --- | --- |
+| A single, hand-blended cost $\int x^\top Q x + u^\top R u$ | One objective **per task / player**, each with its own $Q_i, R_i$ |
+| One Algebraic Riccati Equation | A **coupled** system of Riccati equations solved to its Nash fixed point |
+| Re-tune the whole weight matrix to add a task | **Compose** tasks by adding a player — the others keep their own cost |
+| Continuous time only, by convention | Continuous **and** discrete time, finite or infinite horizon |
+
+`PyDiffGame` ships both regulation (drive the state to the origin) and **signal tracking**
+(drive the state to a target $x_T$), a one-call **LQR-vs-game comparison** harness, cost
+accounting on a common yardstick, and ready-made plotting.
 
 # Installation
 
-Install the latest release from PyPI:
+PyDiffGame is published on [PyPI](https://pypi.org/project/PyDiffGame/) and is
+managed with [**uv**](https://docs.astral.sh/uv/). Add it to your project:
+
+```bash
+uv add PyDiffGame
+```
+
+To run the bundled examples (which additionally need
+[`python-control`](https://python-control.readthedocs.io/)):
+
+```bash
+uv add "PyDiffGame[examples]"
+```
+
+<details>
+<summary><b>Prefer pip?</b> It works as a fallback.</summary>
 
 ```bash
 pip install PyDiffGame
+pip install "PyDiffGame[examples]"   # with the examples extra
 ```
 
-To run the bundled examples (which additionally need [`python-control`](https://python-control.readthedocs.io/)):
+</details>
 
-```bash
-pip install "PyDiffGame[examples]"
-```
-
-To work on the package itself, install it from source in editable mode with the development extras (tests, linter, type checker):
+To work on the package itself, clone it and sync the locked development
+environment with uv:
 
 ```bash
 git clone https://github.com/krichelj/PyDiffGame.git
 cd PyDiffGame
-pip install -e ".[dev]"
+uv sync --extra dev          # creates .venv with the exact locked dependencies
+uv run pre-commit install    # enable the formatting / lint / type-check hooks
 ```
+
+Then run anything through `uv run` (`uv run pytest`,
+`uv run python -m PyDiffGame.examples.MassesWithSpringsComparison`, …). Pip users
+can instead `pip install -e ".[dev]"`, though uv is recommended for the exact
+locked environment.
 
 # Quick start
 
-A plain Linear-Quadratic Regulator is just a one-objective game. The continuous solver matches `scipy.linalg.solve_continuous_are` exactly:
+A plain Linear-Quadratic Regulator is just a one-objective game. The continuous solver
+matches `scipy.linalg.solve_continuous_are` exactly:
 
 ```python
 import numpy as np
@@ -70,7 +127,8 @@ print(lqr.K[0])                     # optimal feedback gain
 print(lqr.is_closed_loop_stable())  # True
 ```
 
-For a multi-player differential game, give one [`Objective`](#input-parameters) per player. Each player owns a slice of the physical input through a decomposition matrix `M`:
+For a multi-player differential game, give one [`Objective`](#input-parameters) per
+player. Each player owns a slice of the physical input through a decomposition matrix `M`:
 
 ```python
 import numpy as np
@@ -96,54 +154,55 @@ print(game.is_closed_loop_stable())                                        # Tru
 
 # Input parameters
 
-A game is described by a system matrix `A`, a set of [`Objective`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/objective.py) objects (one per player), and an input description (`B` together with each objective's decomposition matrix `M`, or per-player matrices `Bs`). Construct one of the concrete solvers — [`ContinuousPyDiffGame`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/continuous.py) or [`DiscretePyDiffGame`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/discrete.py) — with the following parameters:
+A game is described by a system matrix `A`, a set of
+[`Objective`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/objective.py)
+objects (one per player), and an input description (`B` together with each objective's
+decomposition matrix `M`, or per-player matrices `Bs`). Construct one of the concrete
+solvers —
+[`ContinuousPyDiffGame`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/continuous.py)
+or
+[`DiscretePyDiffGame`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/discrete.py)
+— with the following parameters:
 
-* `A` : `np.ndarray` of shape $(n, n)$
->System dynamics matrix
-* `objectives` : `Sequence` of `Objective` of length $N$
->One objective per player; each carries $Q_i$, $R_{ii}$ and optionally $M_i$
-* `B` : `np.ndarray` of shape $(n, m)$, optional
->Full input matrix, used together with each objective's decomposition matrix $M_i$
-* `Bs` : `Sequence` of `np.ndarray`, optional
->Per-player input matrices $B_i$ of shape $(n, m_i)$, an alternative to `B` + `M`
-* `x_0` : `np.ndarray` of shape $(n,)$, optional
->Initial state vector
-* `x_T` : `np.ndarray` of shape $(n,)$, optional
->Final (target) state vector for signal tracking
-* `T_f` : positive `float`, optional
->Finite horizon length. Omit (or pass `None`) for the infinite-horizon problem
-* `P_f` : `Sequence` of `np.ndarray`, optional, default = uncoupled algebraic Riccati solutions
->Terminal condition for the Riccati equation(s)
-* `L` : positive `int`, optional, default `1000`
->Number of time samples
-* `eta` : positive `int`, optional, default `5`
->Number of trailing matrix norms inspected for convergence
-* `epsilon_x`, `epsilon_P` : `float` in $(0, 1)$, optional
->Convergence tolerances for the state and for the Riccati matrices
-* `state_variables_names` : `Sequence` of `str` of length $n$, optional
->LaTeX names (without `$`) for the state variables, used in plots
-* `show_legend` : `bool`, optional, default `True`
->Whether plots include a legend
-* `debug` : `bool`, optional, default `False`
->Emit verbose diagnostics while solving
+| Parameter | Type | Meaning |
+| --- | --- | --- |
+| `A` | `np.ndarray` $(n, n)$ | System dynamics matrix |
+| `objectives` | `Sequence[Objective]` of length $N$ | One objective per player; each carries $Q_i$, $R_{ii}$ and optionally $M_i$ |
+| `B` | `np.ndarray` $(n, m)$, optional | Full input matrix, used with each objective's decomposition matrix $M_i$ |
+| `Bs` | `Sequence[np.ndarray]`, optional | Per-player input matrices $B_i$ of shape $(n, m_i)$ — an alternative to `B` + `M` |
+| `x_0` | `np.ndarray` $(n,)$, optional | Initial state vector |
+| `x_T` | `np.ndarray` $(n,)$, optional | Final (target) state for signal tracking |
+| `T_f` | positive `float`, optional | Finite-horizon length; omit (or `None`) for the infinite-horizon problem |
+| `P_f` | `Sequence[np.ndarray]`, optional | Terminal Riccati condition (default: uncoupled algebraic Riccati solutions) |
+| `L` | positive `int`, default `1000` | Number of time samples |
+| `eta` | positive `int`, default `5` | Number of trailing matrix norms inspected for convergence |
+| `epsilon_x`, `epsilon_P` | `float` in $(0, 1)$, optional | Convergence tolerances for the state and the Riccati matrices |
+| `state_variables_names` | `Sequence[str]` of length $n$, optional | LaTeX names (without `$`) for state variables, used in plots |
+| `show_legend` | `bool`, default `True` | Whether plots include a legend |
+| `debug` | `bool`, default `False` | Emit verbose diagnostics while solving |
 
 An [`Objective`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/objective.py) takes:
 
-* `Q` : `np.ndarray` of shape $(n, n)$ — symmetric positive semi-definite state weight
-* `R` : `np.ndarray` of shape $(m_i, m_i)$ (or a scalar) — symmetric positive definite input weight
-* `M` : `np.ndarray` of shape $(m_i, m)$, optional — decomposition matrix (`None` for a plain LQR objective)
+* `Q` — `np.ndarray` $(n, n)$, symmetric positive **semi**-definite state weight
+* `R` — `np.ndarray` $(m_i, m_i)$ (or a scalar), symmetric positive definite input weight
+* `M` — `np.ndarray` $(m_i, m)$, optional decomposition matrix (`None` for a plain LQR objective)
 
-The helpers `LQRObjective(Q, R)` and `GameObjective(Q, R, M)` are thin constructors for the two common cases.
+The helpers `LQRObjective(Q, R)` and `GameObjective(Q, R, M)` are thin constructors for
+the two common cases.
 
-# Tutorial
+# Tutorial: masses on springs
 
-To demonstrate the package we compare a differential game against an LQR on a system of masses connected by springs:
+To show the package in action we compare a differential game against an LQR on a chain of
+masses connected by springs — a textbook coupled, oscillatory system:
 
 <p align="center">
-    <img align=top src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/src/PyDiffGame/examples/figures/2/two_masses_tikz.png" width="797" height="130"/>
+    <img alt="Two masses connected by springs between two walls" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_schematic.png" width="760"/>
 </p>
 
-The physical input space is decomposed along the *modal* directions of $M^{-1}K$ so that each vibration mode becomes one player of a game. The full example lives in [`MassesWithSpringsComparison.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/MassesWithSpringsComparison.py); here is its essence:
+The physical input space is decomposed along the **modal** directions of $M^{-1}K$, so each
+vibration mode becomes one player of a game. The full example lives in
+[`MassesWithSpringsComparison.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/MassesWithSpringsComparison.py);
+here is its essence:
 
 ```python
 import numpy as np
@@ -168,7 +227,11 @@ for i, (q_i, M_i) in enumerate(zip(q, Ms)):
     modal_weight = np.diag([0.0] * i + [q_i] + [0.0] * (N - 1) + [q_i] + [0.0] * (N - i - 1))
     game_objectives.append(GameObjective(Q=modal_to_state.T @ modal_weight @ modal_to_state, R=r, M=M_i))
 
-lqr_objective = [LQRObjective(Q=np.diag(q + q), R=0.25 * r * I_N)]
+# The LQR baseline optimizes exactly the aggregate of the game's objectives
+# (sum of the per-mode Q_i, and the matching physical input weight r * I), so
+# it is the genuine monolithic optimum to compare the decomposed game against:
+modal_weight_total = np.diag(q + q)
+lqr_objective = [LQRObjective(Q=modal_to_state.T @ modal_weight_total @ modal_to_state, R=r * I_N)]
 
 x_0 = np.array([10.0, 20.0, 0.0, 0.0])
 comparison = PyDiffGameLQRComparison(
@@ -182,58 +245,91 @@ lqr_cost, game_cost = comparison.costs()
 print(f"LQR cost = {lqr_cost:.4g},  game cost = {game_cost:.4g}")
 ```
 
-Running the bundled example end-to-end:
+Run the bundled example end-to-end:
 
 ```bash
-python -m PyDiffGame.examples.MassesWithSpringsComparison
+uv run python -m PyDiffGame.examples.MassesWithSpringsComparison
 ```
 
-produces, for two players, the state-space trajectories of the game vs. the LQR:
+The monolithic LQR is, by construction, the optimal controller for the *aggregate* of the
+game's objectives. The **fully decomposed** modal game — where each vibration mode is
+solved as an independent player, coupled only through the shared dynamics — reproduces that
+monolithic optimum **to numerical precision**: the two state trajectories coincide
+(they differ by ~10⁻⁷) and the costs are equal:
 
 <p align="center">
-    <img align=top src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/src/PyDiffGame/examples/figures/2/2-players_large_1.png" width="400" height="300"/>
-    <img align=top src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/src/PyDiffGame/examples/figures/2/LQR_large_1.png" width="400" height="300"/>
+    <img alt="State trajectories: the decomposed game reproduces the monolithic LQR" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_game_vs_lqr.png" width="860"/>
 </p>
 
-Other worked examples in [`src/PyDiffGame/examples`](https://github.com/krichelj/PyDiffGame/tree/master/src/PyDiffGame/examples) cover an inverted pendulum on a cart, a PVTOL aircraft and a quadrotor.
+<p align="center">
+    <img alt="Cost comparison: the modal game recovers the LQR optimum" src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/readme/masses_cost.png" width="440"/>
+</p>
+
+For this modally-decoupled system the decomposition is **lossless** — and it buys
+**compositionality**: you can add, drop or re-weight a control task by editing a single
+player, without re-tuning one monolithic cost matrix.
+
+> The figures above are regenerated from the live solver by
+> [`tools/generate_readme_figures.py`](https://github.com/krichelj/PyDiffGame/blob/master/tools/generate_readme_figures.py)
+> (`uv run python tools/generate_readme_figures.py`), so they always match the current code.
+
+# More examples
+
+The [`src/PyDiffGame/examples`](https://github.com/krichelj/PyDiffGame/tree/master/src/PyDiffGame/examples)
+directory contains further worked comparisons:
+
+| Example | System |
+| --- | --- |
+| [`MassesWithSpringsComparison.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/MassesWithSpringsComparison.py) | Chain of masses coupled by springs (the tutorial above) |
+| [`InvertedPendulumComparison.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/InvertedPendulumComparison.py) | Inverted pendulum on a cart |
+| [`PVTOL.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/PVTOL.py) · [`PVTOLComparison.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/PVTOLComparison.py) | Planar vertical take-off & landing aircraft |
+| [`QuadRotorControl.py`](https://github.com/krichelj/PyDiffGame/blob/master/src/PyDiffGame/examples/QuadRotorControl.py) | Quadrotor attitude / position control |
 
 # Testing and development
 
-The package ships with a `pytest` suite that validates the solvers against analytical ground truth — the LQR solutions are checked against `scipy`'s algebraic Riccati solvers, the games against their coupled-Riccati residuals and closed-loop stability:
+The package ships with a `pytest` suite that validates the solvers against analytical
+ground truth — LQR solutions are checked against `scipy`'s algebraic Riccati solvers, and
+the games against their coupled-Riccati residuals and closed-loop stability. All tooling
+runs through uv:
 
 ```bash
-pip install -e ".[dev]"
-pytest                                   # run the test suite
-ruff check src/PyDiffGame tests          # lint
+uv sync --extra dev
+uv run pytest                                # run the test suite
+uv run ruff format src/PyDiffGame tests      # auto-format (black-compatible)
+uv run ruff check  src/PyDiffGame tests      # lint
+uv run mypy        src/PyDiffGame            # type-check
 ```
 
-Continuous integration runs the linter and the full suite on Python 3.11–3.14.
+Continuous integration runs the formatter check, linter, type checker and full suite on
+Python 3.11–3.14. See [CONTRIBUTING.md](https://github.com/krichelj/PyDiffGame/blob/master/CONTRIBUTING.md) for details.
 
-# Authors
+# Citing
 
 If you use this work, please cite our paper:
-```
+
+```bibtex
 @inproceedings{pydiffgame_paper,
     author={Kricheli, Joshua Shay and Sadon, Aviran and Arogeti, Shai and Regev, Shimon and Weiss, Gera},
     booktitle={29th Mediterranean Conference on Control and Automation (MED 2021)},
     title={{Composition of Dynamic Control Objectives Based on Differential Games}},
     year={2021},
-    volume={},
-    number={},
     pages={298-304},
     doi={10.1109/MED51440.2021.9480269}}
 ```
 
-Further details can be found in the [citation document](CITATIONS.bib).
+Further details can be found in the [citation document](https://github.com/krichelj/PyDiffGame/blob/master/CITATIONS.bib).
 
 # Acknowledgments
 
-This research was supported in part by the Leona M. and Harry B. Helmsley Charitable Trust through the '_Agricultural, Biological and Cognitive Robotics Initiative_' ('ABC') and by the Marcus Endowment Fund both at Ben-Gurion University of the Negev, Israel.
-This research was also supported by The '_Israeli Smart Transportation Research Center_' ('ISTRC') by The Technion and Bar-Ilan Universities, Israel.
+This research was supported in part by the Leona M. and Harry B. Helmsley Charitable Trust
+through the _‘Agricultural, Biological and Cognitive Robotics Initiative’_ (‘ABC’) and by
+the Marcus Endowment Fund, both at Ben-Gurion University of the Negev, Israel. It was also
+supported by The _‘Israeli Smart Transportation Research Center’_ (‘ISTRC’) by The Technion
+and Bar-Ilan Universities, Israel.
 
 <p align="center">
 <a href="https://istrc.net.technion.ac.il/">
-<img src="https://github.com/krichelj/PyDiffGame/blob/master/images/Logo_ISTRC_Green_English.png?raw=true" height="80" alt="ISTRC"/>
+<img src="https://raw.githubusercontent.com/krichelj/PyDiffGame/master/images/Logo_ISTRC_Green_English.png" height="80" alt="ISTRC"/>
 </a>
 &emsp;
 <a href="https://in.bgu.ac.il/en/Pages/default.aspx">
@@ -253,7 +349,7 @@ This research was also supported by The '_Israeli Smart Transportation Research 
 </a>
 </p>
 
-# Star History
+# Star history
 
 <p align="center">
 <a href="https://star-history.com/#krichelj/PyDiffGame&Date">

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Increment the project version using single-digit, carry-at-9 components.
+
+The version is ``X.Y.Z`` where each component rolls over at 9: incrementing the
+patch past 9 carries into the minor, and the minor past 9 carries into the major
+(e.g. ``2.0.9 -> 2.1.0`` and ``2.9.9 -> 3.0.0``). The major keeps growing.
+
+It updates the single source of truth in both ``pyproject.toml`` and
+``src/PyDiffGame/__init__.py`` and prints the new version to stdout.
+
+Usage::
+
+    python tools/bump_version.py            # bump the files, print the new version
+    python tools/bump_version.py --dry-run  # print the next version without writing
+    python tools/bump_version.py --current  # print the current version
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+INIT = ROOT / "src" / "PyDiffGame" / "__init__.py"
+
+_PYPROJECT_RE = re.compile(r'^(version\s*=\s*)"([^"]+)"', re.MULTILINE)
+_INIT_RE = re.compile(r'^(__version__\s*=\s*)"([^"]+)"', re.MULTILINE)
+
+
+def increment_version(version: str) -> str:
+    """Return the next version, rolling each component over at 9 (carry up)."""
+    parts = version.split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        raise ValueError(f"expected an 'X.Y.Z' numeric version, got {version!r}")
+    major, minor, patch = (int(p) for p in parts)
+    patch += 1
+    if patch > 9:
+        patch, minor = 0, minor + 1
+        if minor > 9:
+            minor, major = 0, major + 1
+    return f"{major}.{minor}.{patch}"
+
+
+def read_current_version() -> str:
+    match = _PYPROJECT_RE.search(PYPROJECT.read_text())
+    if match is None:
+        raise SystemExit("could not find 'version = \"...\"' in pyproject.toml")
+    return match.group(2)
+
+
+def write_version(new_version: str) -> None:
+    """Write ``new_version`` into both pyproject.toml and __init__.py."""
+    PYPROJECT.write_text(_PYPROJECT_RE.sub(rf'\1"{new_version}"', PYPROJECT.read_text(), count=1))
+    INIT.write_text(_INIT_RE.sub(rf'\1"{new_version}"', INIT.read_text(), count=1))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run", action="store_true", help="print the next version without writing")
+    group.add_argument("--current", action="store_true", help="print the current version and exit")
+    args = parser.parse_args()
+
+    current = read_current_version()
+    if args.current:
+        print(current)
+        return
+
+    new_version = increment_version(current)
+    if not args.dry_run:
+        write_version(new_version)
+    print(new_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **uv-first docs:** README now leads with `uv add` / `uv sync` and keeps `pip` as a documented fallback (collapsible). The "Testing and development" section already uses uv.
- **PyPI ↔ GitHub README parity:** `pyproject.toml` already uses `README.md` as the PyPI long-description, but its image/file links were relative (broken on PyPI). Converted them to absolute `raw.githubusercontent.com` / `github.com/blob` URLs so the PyPI page renders identically to GitHub.
- **docs/README.md** was stale (old *rigged* LQR comparison + old figures) — synced it to the canonical README.
- **Automatic versioning:** new `tools/bump_version.py` increments `X.Y.Z` with single-digit, **carry-at-9** components (`2.0.9 → 2.1.0`, `2.9.9 → 3.0.0`), updating `pyproject.toml` and `__init__.py` together. The publish workflow now auto-increments + commits the bump before building/publishing/releasing, so **every release bumps automatically**.
- **CONTRIBUTING** documents the auto-bump release flow; **CLAUDE.md** records the uv-first + carry-at-9 conventions.

After merge, running the publish workflow will take the version from `2.0.0` → `2.0.1` automatically.

Verified locally: carry logic (`2.0.9→2.1.0`, `2.9.9→3.0.0`), `uv` import/build, ruff, mypy, and the full pytest suite (29) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvuS9HKbnZAwwFJyBkyHc)_